### PR TITLE
Parallel executions of @mpf.run functions

### DIFF
--- a/mpf/__init__.py
+++ b/mpf/__init__.py
@@ -380,7 +380,7 @@ def run_experiment(n_runs=3, wsp_target=None, log_ex=False):
                     row.update(result)
                     mpf_log = client[machine_id].pull(log_name, block=True)
                     for line, out in mpf_log:
-                        run_logger.info('\n'.join([line] + out), extra={'function': async_fn, 'role': role})
+                        run_logger.info('\n'.join([line] + out), extra={'function': async_fn, 'role': async_role})
                     client[machine_id].execute(f"del {log_name}")
                 async_results = []
             if role in variables:


### PR DESCRIPTION
This brings support for the optional parallel argument in mpf.run that will make the registered function asynchronous. Its result and %ex logs will be fetched before executing the next non-parallel registered function.

This can greatly decrease the time to perform experience setups in @mpf.run functions.

The PR required reworking how %ex logs are stored. They are still stored in a global variable but whose name will be unique under the condition of non-repeating role, link and function name. For registered functions that will not overlap (i.e. they do not set the parallel argument consecutively), this is not an issue.

All registered functions, either via @mpf.run or @mpf.init, are not required to accept the mpf_ctx argument as a consequence.